### PR TITLE
WoS Bestiary Text Fix

### DIFF
--- a/NPCs/Bosses/WallofSteel.cs
+++ b/NPCs/Bosses/WallofSteel.cs
@@ -81,7 +81,7 @@ public class WallofSteel : ModNPC
         bestiaryEntry.Info.AddRange(new IBestiaryInfoElement[]
         {
             BestiaryDatabaseNPCsPopulator.CommonTags.SpawnConditions.Biomes.TheUnderworld,
-            new FlavorTextBestiaryInfoElement("A rather secret and unusual recreation of a being from the past, capable of attacks seen from other creations while having some of its own unique ones. At least a certain individual out there would be thankful that the calling of such thing does not result in a fiery death.")
+            new FlavorTextBestiaryInfoElement("A rather secret and unusual recreation of a being from the past, capable of attacks seen from other creations while having some of its own unique ones. At least a certain individual out there would be thankful that the calling of such thing does not result in a fiery death."),
         });
     }
 


### PR DESCRIPTION
We missed a comma at the end of the entry text line